### PR TITLE
Add support for severity/confidence ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 *venv/
 .idea/
+
 local/
 dist/
 build/
 DCSO_TIE*
 MANIFEST
+
+.DS_Store
+__pycache__

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015, 2019, Deutsche Cyber-Sicherheitsorganisation
+Copyright (c) 2015, 2020, Deutsche Cyber-Sicherheitsorganisation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ After installation, the add-on needs to be configured.
 
 ## Splunk App Setup Page
 
-After installation you must setup the app or add-on.
+Important: when after saving an error appears in the Splunk Web tool, the configuration is stored, but
+it does not give much information what went wrong.
+To find out the issue, you will have to look in the log file (see below).
 
 An API or Machine Token is required to access the Threat Intelligence Engine or TIE. Both the legacy
 token created through `tie.dcso.de` and the newer tokens created through `portal.dcso.de` are supported.
@@ -54,6 +56,7 @@ There are few more details about the configuration:
 * **tie2index.py** script: make sure to enable this by un-checking the checkbox.
 * **Index for IoCs**: the index used to store IoCs (events). When using a custom index, it
   must already exist.
+* **Severity & Confidence**: can be provided as number as well as range (or example `1-` or `30-90`).
 
 ## Standard Filter
 
@@ -78,6 +81,9 @@ The default ranges of the filters are mentioned in the section 'Standard Filter'
 
 This add-on will log errors, warnings, and other informative messages to a separate log file within
 the folder `${SPLUNK_HOME}/var/log/splunk`. The file is called `dcso_tie.log` and is rotated 6 times.
+
+The entries in this log file are stored, when executed by Splunk, as JSON. This makes it ready to be
+monitored by Splunk itself.
 
 # Contact
 
@@ -113,7 +119,7 @@ $ TIE_TOKEN=YOURTOKENHERE python tests/tests.py
 
 ## Deployment
 
-The add-on can be packages using the normal `distutils` command. However, for Splunk we need
+The add-on can be packaged using the normal `distutils` command. However, for Splunk we needed
 to adapt a bit so that it is easy to create, deploy and install.
 
 ## For Splunk
@@ -148,4 +154,3 @@ Archive:  dist/DCSO_TIE_Splunk_AddOn2-2.0.0b6.zip
 # License
 
 See LICENSE file included in the repository.
-

--- a/bin/dcso_tie_filter_handler.py
+++ b/bin/dcso_tie_filter_handler.py
@@ -61,26 +61,26 @@ class ConfigApp(admin.MConfigHandler):
         name = self.callerArgs.id
         args = self.callerArgs
 
-        if self.callerArgs.data['ip_confidence'][0] is None:
-            self.callerArgs.data['ip_confidence'][0] = ''
-        if self.callerArgs.data['ip_severity'][0] is None:
-            self.callerArgs.data['ip_severity'][0] = ''
-        if self.callerArgs.data['dom_confidence'][0] is None:
-            self.callerArgs.data['dom_confidence'][0] = ''
-        if self.callerArgs.data['dom_severity'][0] is None:
-            self.callerArgs.data['dom_severity'][0] = ''
-        if self.callerArgs.data['url_confidence'][0] is None:
-            self.callerArgs.data['url_confidence'][0] = ''
-        if self.callerArgs.data['url_severity'][0] is None:
-            self.callerArgs.data['url_severity'][0] = ''
-        if self.callerArgs.data['email_confidence'][0] is None:
-            self.callerArgs.data['email_confidence'][0] = ''
-        if self.callerArgs.data['email_severity'][0] is None:
-            self.callerArgs.data['email_severity'][0] = ''
-        if self.callerArgs.data['confidence'][0] is None:
-            self.callerArgs.data['confidence'][0] = ''
-        if self.callerArgs.data['severity'][0] is None:
-            self.callerArgs.data['severity'][0] = ''
+        if args.data['ip_confidence'][0] is None:
+            args.data['ip_confidence'][0] = ''
+        if args.data['ip_severity'][0] is None:
+            args.data['ip_severity'][0] = ''
+        if args.data['dom_confidence'][0] is None:
+            args.data['dom_confidence'][0] = ''
+        if args.data['dom_severity'][0] is None:
+            args.data['dom_severity'][0] = ''
+        if args.data['url_confidence'][0] is None:
+            args.data['url_confidence'][0] = ''
+        if args.data['url_severity'][0] is None:
+            args.data['url_severity'][0] = ''
+        if args.data['email_confidence'][0] is None:
+            args.data['email_confidence'][0] = ''
+        if args.data['email_severity'][0] is None:
+            args.data['email_severity'][0] = ''
+        if args.data['confidence'][0] is None:
+            args.data['confidence'][0] = ''
+        if args.data['severity'][0] is None:
+            args.data['severity'][0] = ''
 
         # Since we are using a conf file to store parameters, write them to the [setupentity] stanza
         # in app_name/local/myappsetup.conf

--- a/default/setup.xml
+++ b/default/setup.xml
@@ -1,12 +1,22 @@
 <setup>
     <block title="Configuration of DCSO TIE Splunk AddOn" endpoint="tie/tiesetupendpoint" entity="tie">
-        <text>
-            &lt;strong&gt;API Token&lt;/strong&gt;: either a DCSO Portal Token or a (legacy) TIE Token &lt;br/&gt;&lt;br/&gt;
-            &lt;strong&gt;Initial IoC Sequence Number&lt;/strong&gt;: here you can specify at which sequence number to
-            start
-            fetching IoC. This is useful when you have an index filled, and you are re-installing the add-on new.
-            Leave zero (0) to start from NOW minus 30 days.&lt;br/&gt;&lt;br/&gt;
-        </text>
+        <text><![CDATA[
+            <div>
+                <div style="border: 1px solid darkred; padding: 10px; margin: 0 20px 10px 20px">
+                    <strong>Note</strong>: errors in configuration are currently only visible in the log file
+                    <code style="font-size: smaller">$SPLUNK_HOME/var/log/splunk/dcso_tie.log</code>.
+                    If an error is reported here, you will need to look into the log file.
+                </div>
+                <p class="helpText" style="margin: 10px 20px 10px 20px">
+                    <strong>API Token</strong>: either a DCSO Portal Token or a (legacy) TIE Token.
+                </p>
+                <p class="helpText" style="margin: 10px 20px 10px 20px">
+                    <strong>Initial IoC Sequence Number</strong>: here you can specify at which sequence number to
+                    start fetching IoC. This is useful when you have an index filled, and you are re-installing the
+                    add-on new. Leave zero (0) to start from NOW minus 30 days.
+                </p>
+            </div>
+        ]]></text>
         <input field="token">
             <font color="red">
                 <b>*</b>
@@ -24,7 +34,25 @@
     </block>
 
     <block title="Configure DCSO TIE Filter" endpoint="tie/tiefilterendpoint" entity="filter">
-        <text>Here you can configure various filters for DCSO TIE IoCs.</text>
+        <text><![CDATA[
+            <div>
+            <p class="helpText" style="margin: 10px 20px 10px 20px">
+                Here you can configure various filters for DCSO TIE IoCs.
+            </p>
+            <p class="helpText" style="margin: 10px 20px 10px 20px">
+                Severity and Confidence can be provided as number or as range. For Severity values from 0 till 6 are
+                allowed; Confidence is specified from 0 till 100.<br/>
+                Value and ranges can be formatted as follows:
+            </p>
+            <ul style="color: #6b7785; padding-left: 2rem; margin: 10px 20px 10px 20px">
+                <li><code style="font-size: smaller">1</code> means 1 and higher</li>
+                <li><code style="font-size: smaller">1-</code> means 1 and higher</li>
+                <li><code style="font-size: smaller">1-3</code> means 1 to 3</li>
+                <li><code style="font-size: smaller">-3</code> means 0 (zero) till 4</li>
+                <li><code style="font-size: smaller">30-90</code> means 30 to 90</li>
+            </ul>
+            </div>
+        ]]></text>
         <input field="ip_confidence">
             <label>Confidence for IP</label>
             <type>text</type>
@@ -58,11 +86,11 @@
             <type>text</type>
         </input>
         <input field="confidence">
-            <label>Confidence for General</label>
+            <label>Confidence any other data type</label>
             <type>text</type>
         </input>
         <input field="severity">
-            <label>Severity for General</label>
+            <label>Severity for any other data type</label>
             <type>text</type>
         </input>
 
@@ -70,20 +98,19 @@
 
 
     <block title="Enable Scripts" endpoint="data/inputs/script" entity=".%2Fbin%2Ftie2index.py">
-        <text>
-            The &lt;strong&gt;tie2index.py&lt;/strong&gt; script is responsible for fetching IoCs from DCSO TIE.
-            Specify here with which  interval, and into which index to store the events. When using non-default
-            index, the index must be available in the Indexer or Heavy Forwarder.&lt;br/&gt;
-            &lt;br/&gt;
-            &lt;strong&gt;Make sure to uncheck to enable.&lt;/strong&gt;&lt;br/&gt;
-            &lt;br/&gt;
-        </text>
-        <input field="disabled">
-            <label>tie2index.py (checked means disabled)</label>
+        <text><![CDATA[
+            <p class="helpText" style="margin: 10px 20px 10px 20px">
+            The <strong>tie2index.py</strong> script is responsible for fetching IoCs from DCSO TIE.
+            Specify here with which interval, and into which index to store the events. When using non-default
+            index, the index must be available in the Indexer or Heavy Forwarder.
+            </p>
+        ]]></text>
+        <input field="enabled">
+            <label>Enable $name$</label>
             <type>bool</type>
         </input>
         <input field="interval">
-            <label>Interval for [$name$]</label>
+            <label>Interval (seconds)</label>
             <type>text</type>
         </input>
         <input field="index">
@@ -94,9 +121,12 @@
     </block>
 
     <block title="Configure Proxy" endpoint="tie/tieproxyendpoint" entity="proxy">
-        <text>Here you define the HTTP proxy to use when connecting with DCSO TIE. Leave blank if no proxy is
+        <text><![CDATA[
+            <p class="helpText" style="margin: 10px 20px 10px 20px">
+            Here you define the HTTP proxy to use when connecting with DCSO TIE. Leave blank if no proxy is
             required.
-        </text>
+            </p>
+        ]]></text>
         <input field="host">
             <label>Host</label>
             <type>text</type>

--- a/lib/_version.py
+++ b/lib/_version.py
@@ -1,3 +1,3 @@
 # Copyright (c) 2020, DCSO GmbH
 
-__version__ = "2.0.0b6"
+__version__ = "2.0.0b7"

--- a/lib/dcsotie/errors.py
+++ b/lib/dcsotie/errors.py
@@ -10,3 +10,7 @@ class TIEConnectionError(TIEError):
 
 class TIEAPIError(TIEError):
     pass
+
+
+class TIEConfigError(TIEError):
+    pass

--- a/lib/dcsotie/utils.py
+++ b/lib/dcsotie/utils.py
@@ -1,8 +1,12 @@
 # Copyright (c) 2020, DCSO GmbH
 
-from typing import Dict, Optional, NoReturn
+from typing import Dict, Optional, Tuple, Union
+import re
 
 from requests.utils import parse_header_links
+
+_RE_RANGE_STR = re.compile(r'^(\d*)-(\d*)$')
+ARange = Union[int, Tuple[int, int], str]
 
 
 class APIRelationshipLinks:
@@ -42,3 +46,79 @@ class APIRelationshipLinks:
             result[rel] = getattr(self, rel, None)
 
         return result
+
+
+class Range:
+    """
+    Range definition
+    """
+    max_upper = None
+
+    def __init__(self, r: ARange):
+        self.lower = 0
+        self.upper = None
+
+        if isinstance(r, int):
+            if r < 0:
+                raise ValueError("range lower cannot be negative")
+            self.lower = r
+        elif isinstance(r, (tuple, list)):
+            self.lower = r[0]
+            self.upper = r[1]
+        elif isinstance(r, str):
+            r = r.strip()
+            try:
+                self.lower = int(r)
+                if self.lower < 0:
+                    raise ValueError("range cannot be negative")
+            except (TypeError, ValueError):
+                # next up is to get range syntax from string
+                m = _RE_RANGE_STR.match(r)
+                if m is None:
+                    raise ValueError("range string not valid; was {}".format(r))
+                self.lower = int(m.group(1)) if m.group(1) != '' else None
+                self.upper = int(m.group(2)) if m.group(2) != '' else None
+                if self.lower is None and self.upper is None:
+                    raise ValueError("range not valid; was {}".format(r))
+        else:
+            raise ValueError("range string not valid; was {}".format(r))
+
+        if self.__class__.max_upper is not None:
+            if self.upper is None:
+                self.upper = self.__class__.max_upper
+            elif self.upper > self.__class__.max_upper:
+                raise ValueError("range should be between 0 and {} (was {})".format(
+                    self.__class__.max_upper, str(self)))
+
+        if self.upper is not None and self.lower is not None and self.lower > self.upper:
+            raise ValueError("range lower is higher than upper; was {}".format(r))
+
+    def in_range(self, i: int) -> bool:
+        if self.lower is None:
+            return i <= self.upper
+        if self.upper is None:
+            return i >= self.lower
+
+        return self.lower <= i <= self.upper
+
+    def __str__(self) -> str:
+        return '{}-{}'.format(
+            self.lower if self.lower is not None else '',
+            self.upper if self.upper is not None else '')
+
+    def __eq__(self, other):
+        return other.lower == self.lower and other.upper == self.upper
+
+
+class SeverityRange(Range):
+    """
+    SeverityRange is a Range which lower is 0 and upper maximum 6.
+    """
+    max_upper = 6
+
+
+class ConfidenceRange(Range):
+    """
+    ConfidenceRange is a Range which lower is 0 and upper maximum 100.
+    """
+    max_upper = 100

--- a/lib/dcsotiesplunk/config.py
+++ b/lib/dcsotiesplunk/config.py
@@ -1,20 +1,23 @@
 # Copyright (c) 2020, DCSO GmbH
 
 from configparser import ConfigParser
-from typing import Optional, Any, Union
+from typing import NoReturn, Optional, Any, Union
+
+from dcsotie.errors import TIEConfigError
+from dcsotie.utils import Range, SeverityRange, ConfidenceRange
 
 CONFIG_SCHEMA = {
     'filter': {
-        'ip_confidence': (int, 80),
-        'ip_severity': (int, 1),
-        'dom_confidence': (int, 80),
-        'dom_severity': (int, 1),
-        'url_confidence': (int, 80),
-        'url_severity': (int, 1),
-        'email_confidence': (int, 80),
-        'email_severity': (int, 1),
-        'confidence': (int, 80),
-        'severity': (int, 2),
+        'ip_confidence': (ConfidenceRange, 80),
+        'ip_severity': (SeverityRange, 1),
+        'dom_confidence': (ConfidenceRange, 80),
+        'dom_severity': (SeverityRange, 1),
+        'url_confidence': (ConfidenceRange, 80),
+        'url_severity': (SeverityRange, 1),
+        'email_confidence': (ConfidenceRange, 80),
+        'email_severity': (SeverityRange, 1),
+        'confidence': (ConfidenceRange, 80),
+        'severity': (SeverityRange, 2),
     },
     'tie': {
         'token': (str, ''),
@@ -44,6 +47,7 @@ def read_conf_from_file(file: Optional[str] = None) -> Any:
 
     :param file: file to be read
     :return: configuration as read from the configuration file.
+    :raises TIEConfigError: when configuration contains errors.
     """
     cfg = ConfigParser()
 
@@ -72,10 +76,24 @@ def normalize_configuration(configuration: Union[ConfigParser, dict]) -> dict:
         if section not in res:
             res[section] = {}
         for k, s in CONFIG_SCHEMA[section].items():
-            try:
-                res[section][k] = s[0](configuration[section][k])
-            except KeyError:
-                res[section][k] = s[1]
+            cfg_value = configuration[section][k]
+
+            if issubclass(s[0], Range):
+                if isinstance(cfg_value, Range):
+                    # we already have a range
+                    res[section].setdefault(k, cfg_value)
+                else:
+                    try:
+                        if k.endswith('severity'):
+                            res[section].setdefault(k, SeverityRange(cfg_value))
+                        elif k.endswith('confidence'):
+                            res[section].setdefault(k, ConfidenceRange(cfg_value))
+                        else:
+                            res[section].setdefault(k, Range(cfg_value))
+                    except ValueError as exc:
+                        raise TIEConfigError(str(exc))
+            else:
+                res[section].setdefault(k, s[0](cfg_value))
 
     return res
 
@@ -87,6 +105,58 @@ def default_configuration() -> dict:
         if section not in res:
             res[section] = {}
         for k, s in CONFIG_SCHEMA[section].items():
-            res[section][k] = s[1]
+            if issubclass(s[0], Range):
+                res[section][k] = s[0](s[1])
+            else:
+                res[section][k] = s[1]
 
     return res
+
+
+def normalize_splunk_setup_args(data: dict, labels: Optional[dict] = None) -> NoReturn:
+    """
+    Normalizes the data entered when setting up the Splunk app or add-on. The data
+    argument is Splunk's ConfigApp.callerArgs.data attribute. It is a key/value
+    mapping.
+
+    :param data: dictionary containing configuration gathered through setup.xml
+    :param labels: optional labels for the keys within data (helpful for more human readable errors)
+    :raises TIEConfigError: when a value is invalid
+    """
+    if labels is None:
+        labels = {}
+
+    for k, v in data.items():
+        label = labels.get(k, k)
+
+        #
+        # single value entries
+        #
+        try:
+            v = v[0].strip()  # whitespace at both ends is useless
+        except AttributeError:
+            # if not a string, all is ok
+            pass
+
+        if k.endswith('severity'):
+            try:
+                data[k][0] = str(SeverityRange(v))
+            except ValueError:
+                raise TIEConfigError("invalid range value for {} (should be between 0 and 6)".format(label))
+        elif k == 'token':
+            if not v:
+                raise TIEConfigError("{} is required".format(label))
+            data[k][0] = str(v)
+        elif k.endswith('confidence'):
+            try:
+                data[k][0] = str(ConfidenceRange(v))
+            except ValueError:
+                raise TIEConfigError("invalid range value for {} (should be between 0 and 100)".format(label))
+        elif k == 'start_ioc_seq':
+            try:
+                v = int(v)
+                if v < 0:
+                    raise ValueError
+                data[k][0] = str(v)
+            except (TypeError, ValueError):
+                raise TIEConfigError("invalid positive number for {}".format(label))

--- a/lib/dcsotiesplunk/filtering.py
+++ b/lib/dcsotiesplunk/filtering.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2017, 2020, DCSO GmbH
+
+import json
+import sys
+import os
+
+# we change the path so that this app can run within the Splunk environment
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from dcsotie.errors import TIEError
+from dcsotiesplunk.logger import get_logger
+
+logger = get_logger().getChild('.filtering')
+
+DATA_TYPE_FILTER_MAP = {
+    'IPv4': 'ip',
+    'URLVerbatim': 'url',
+    'DomainName': 'dom',
+}
+
+
+def filter_iocs(iocs, filters, fp=sys.stdout):
+    tmpl_filters = {
+        'confidence': None,
+        'max_severity': None
+    }
+    filter_cache = {}
+
+    for ioc in iocs:
+        try:
+            max_confidence = int(ioc['max_confidence'])
+        except (TypeError, ValueError):
+            logger.error("bad value for max_confidence; was {}".format(ioc['max_confidence']))
+            continue
+
+        try:
+            max_severity = int(ioc['max_severity'])
+        except (TypeError, ValueError):
+            logger.error("bad value for max_severity; was {}".format(ioc['max_severity']))
+            continue
+
+        dt = ioc['data_type']
+        try:
+            f = filter_cache[dt]
+        except KeyError:
+            # warm up
+            f = filter_cache[dt] = tmpl_filters.copy()
+            try:
+                p = DATA_TYPE_FILTER_MAP[ioc['data_type']]
+                f['confidence'] = filters[p + '_confidence']
+                f['max_severity'] = filters[p + '_severity']
+            except KeyError:
+                f['confidence'] = filters['confidence']
+                f['max_severity'] = filters['severity']
+
+        try:
+            if (f['confidence'].in_range(max_confidence)
+                    and f['max_severity'].in_range(max_severity)):
+                print(json.dumps(ioc), file=fp)
+        except AttributeError as exc:
+            raise TIEError(str(exc))

--- a/lib/dcsotiesplunk/logger.py
+++ b/lib/dcsotiesplunk/logger.py
@@ -2,17 +2,69 @@
 
 import logging
 from logging import handlers
+from typing import Optional
+import time
 import os
 import sys
+import json
+import traceback
+from collections import OrderedDict
 
 _SPLUNK_HOME_ENV = 'SPLUNK_HOME'
 _SPLUNK_LOGS = 'var/log/splunk/'  # relative to SPLUNK_HOME; never starts with /
 _DCSO_TIE_LOGFILE = 'dcso_tie.log'
 
 
+class UTCFormatter(logging.Formatter):
+    default_time_format = '%Y-%m-%dT%H:%M:%S.uuuZ'
+    converter = time.gmtime
+
+    def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
+        """
+
+        :param record: a LogRecord instance
+        :param datefmt: this format is ignored
+        :return: RFC 3339 string, for example 2020-05-28T07:24:30.721Z
+        """
+        ct = self.converter(record.created)
+        # we do not use the self.default_msec_format attribute
+        return time.strftime(self.default_time_format, ct).replace(".uuu", ".{:03.0f}".format(record.msecs))
+
+
+class UTCJSONFormatter(UTCFormatter):
+    def formatException(self, ei) -> list:
+        return [l for l in traceback.TracebackException(
+                type(ei[1]), ei[1], ei[2], limit=None).format(chain=True)]
+
+
+    def format(self, record: logging.LogRecord) -> str:
+        record.message = record.getMessage()
+
+        rec = OrderedDict([
+            ("time", self.formatTime(record, self.datefmt)),
+            ("level", record.levelname),
+            ("name", record.name),
+            ("message", record.message),
+        ])
+
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                rec["exceptionInfo"] = self.formatException(record.exc_info)
+
+        if record.stack_info:
+            rec["stackInfo"] = self.formatStack(record.stack_info)
+
+        return json.dumps(rec)
+
+
 def get_logger(level: int = logging.INFO) -> logging.Logger:
     logger = logging.getLogger("dcso.tie.splunk")
     logger.propagate = False
+
+    if hasattr(logger, 'initialized'):
+        return logger
 
     try:
         logger.setLevel(level)
@@ -20,11 +72,13 @@ def get_logger(level: int = logging.INFO) -> logging.Logger:
         # invalid level, we use default logging.INFO
         logger.setLevel(logging.INFO)
 
-    formatter = logging.Formatter('%(asctime)s %(levelname)s %(module)s:%(lineno)d %(message)s')
+    fmtText = '%(asctime)s %(levelname)s [%(name)s] %(message)s'
 
+    formatter = UTCFormatter(fmt=fmtText)
     splunk_home = os.getenv(_SPLUNK_HOME_ENV, None)
 
     if splunk_home:
+        formatter = UTCJSONFormatter(fmt=fmtText)  # although format is not use, pass a long anyway
         f = os.path.join(splunk_home, _SPLUNK_LOGS, _DCSO_TIE_LOGFILE)
         handler = handlers.RotatingFileHandler(f, mode='a', maxBytes=10000000, backupCount=6)
         handler.setFormatter(formatter)
@@ -35,4 +89,5 @@ def get_logger(level: int = logging.INFO) -> logging.Logger:
     if handler:
         logger.addHandler(handler)
 
+    setattr(logger, 'initialized', True)
     return logger

--- a/tests/dcsotie_test/iosfetcher_test.py
+++ b/tests/dcsotie_test/iosfetcher_test.py
@@ -7,6 +7,11 @@ import sys
 import tempfile
 import unittest
 
+try:
+    import dcsotie
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
+
 from dcsotie.fetchers import IoCFetcher
 from dcsotie.errors import TIEConnectionError
 from dcsotie import TIE_TOKEN
@@ -57,7 +62,7 @@ class TestIOCFetcher(unittest.TestCase):
         self.assertEqual((1, 39.9), f.timeout)
 
     def test_fetch_cnx_error(self):
-        f = IoCFetcher(api_uri='http://localhost.local:8080', token='mytoken', timeout=0.5)
+        f = IoCFetcher(api_uri='http://localhost.local:8080', token='mytoken', timeout=(1, 3))
         with self.assertRaises(TIEConnectionError) as ctx:
             f.fetch()
         self.assertTrue("failed connecting with TIEngine" in str(ctx.exception))
@@ -120,6 +125,4 @@ class TestIOCFetcher(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
-
     unittest.main()

--- a/tests/dcsotie_test/utils_test.py
+++ b/tests/dcsotie_test/utils_test.py
@@ -4,7 +4,12 @@ import os
 import sys
 import unittest
 
-from dcsotie.utils import APIRelationshipLinks
+try:
+    import dcsotie
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
+
+from dcsotie.utils import APIRelationshipLinks, Range
 
 TEST_LINK_HEADER = '''
 <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=60>; rel=previous, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=100>; rel=next, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=680>; rel=last, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=0>; rel=first
@@ -36,6 +41,63 @@ class TestAPIRelationshipLinks(unittest.TestCase):
         self.assertIsNotNone(links.previous)
 
 
+class TestRange(unittest.TestCase):
+    def test_int(self):
+        r = Range(3)
+        self.assertEqual(3, r.lower)
+        self.assertIsNone(r.upper)
+
+        with self.assertRaises(ValueError):
+            Range(-2)
+
+    def test_tuple(self):
+        r = Range((2, 5))
+        self.assertEqual(2, r.lower)
+        self.assertEqual(5, r.upper)
+        self.assertTrue(r.in_range(3))
+
+        with self.assertRaises(ValueError):
+            Range((5, 2))
+
+    def test_str_lower_upper(self):
+        r = Range('2-5')
+        self.assertEqual(2, r.lower)
+        self.assertEqual(5, r.upper)
+        self.assertTrue(r.in_range(3))
+        self.assertTrue(r.in_range(2))
+        self.assertTrue(r.in_range(5))
+        self.assertFalse(r.in_range(6))
+        self.assertFalse(r.in_range(1))
+
+    def test_str_only_upper(self):
+        r = Range('-5')
+        self.assertIsNone(r.lower)
+        self.assertEqual(5, r.upper)
+        self.assertTrue(r.in_range(1))
+        self.assertFalse(r.in_range(6))
+
+    def test_str_integer(self):
+        r = Range('3')
+        self.assertIsNone(r.upper)
+        self.assertEqual(3, r.lower)
+        self.assertFalse(r.in_range(1))
+        self.assertTrue(r.in_range(6))
+
+    def test_str_only_lower(self):
+        r = Range('2-')
+        self.assertEqual(2, r.lower)
+        self.assertIsNone(r.upper)
+        self.assertFalse(r.in_range(1))
+        self.assertTrue(r.in_range(2))
+        self.assertTrue(r.in_range(6))
+
+    def test_str_invalid(self):
+        with self.assertRaises(ValueError):
+            Range('-')
+
+        with self.assertRaises(ValueError):
+            Range('asdf-5')
+
+
 if __name__ == '__main__':
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
     unittest.main()

--- a/tests/dcsotiesplunk_test/config_test.py
+++ b/tests/dcsotiesplunk_test/config_test.py
@@ -4,7 +4,15 @@ import os
 import sys
 import unittest
 
+try:
+    import dcsotie
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
+
 from dcsotiesplunk.config import normalize_configuration, CONFIG_SCHEMA, default_configuration
+from dcsotie.utils import SeverityRange
+from dcsotie.errors import TIEConfigError
+
 
 TEST_LINK_HEADER = '''
 <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=60>; rel=previous, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=100>; rel=next, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=680>; rel=last, <https://tie.dcso.de/api/v1/raw_iocs?limit=20&data_type=domainname%2Cipv4&offset=0>; rel=first
@@ -19,28 +27,36 @@ TEST_LINK_HEADER_EXP = {
 
 class TestNormalizeConfig(unittest.TestCase):
     def test_normalize(self):
-        have = {
-            'filter': {
-                'url_severity': "3",
-            }
-        }
+        have = default_configuration()
+        have['filter']['url_severity'] = '3'
 
         res = normalize_configuration(have)
-        self.assertIsInstance(res['filter']['url_severity'], int)
-        self.assertEqual(3, res['filter']['url_severity'])
-        self.assertEqual(CONFIG_SCHEMA['filter']['dom_confidence'][1], res['filter']['dom_confidence'])
-        self.assertEqual(CONFIG_SCHEMA['tie']['feed_api'][1],
-                         res['tie']['feed_api'])
+        self.assertIsInstance(res['filter']['url_severity'], SeverityRange)
+
+        exp = CONFIG_SCHEMA['filter']['url_severity'][0](have['filter']['url_severity'])
+        self.assertEqual(exp, res['filter']['url_severity'],
+                         msg="Range {} != Range {}".format(exp, res['filter']['url_severity']))
+
+        self.assertEqual(CONFIG_SCHEMA['tie']['feed_api'][1], res['tie']['feed_api'])
+
+    def test_wrong_value_severity(self):
+        have = default_configuration()
+        have['filter']['url_severity'] = '3-foobar'
+
+        with self.assertRaises(TIEConfigError) as ctx:
+            normalize_configuration(have)
+
+        self.assertEqual("range string not valid; was 3-foobar", str(ctx.exception))
 
 
 class TestDefaultConf(unittest.TestCase):
     def test_default(self):
         res = default_configuration()
-        self.assertEqual(CONFIG_SCHEMA['filter']['dom_confidence'][1], res['filter']['dom_confidence'])
-        self.assertEqual(CONFIG_SCHEMA['tie']['feed_api'][1],
-                         res['tie']['feed_api'])
+
+        exp = CONFIG_SCHEMA['filter']['dom_confidence'][0](CONFIG_SCHEMA['filter']['dom_confidence'][1])
+        self.assertEqual(exp, res['filter']['dom_confidence'])
+        self.assertEqual(CONFIG_SCHEMA['tie']['feed_api'][1], res['tie']['feed_api'])
 
 
 if __name__ == '__main__':
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
     unittest.main()

--- a/tests/dcsotiesplunk_test/setup_test.py
+++ b/tests/dcsotiesplunk_test/setup_test.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2020, DCSO GmbH
+
+import sys
+import os
+import unittest
+
+try:
+    import dcsotie
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
+
+from dcsotie.errors import TIEConfigError
+from dcsotie.utils import Range, ConfidenceRange, SeverityRange
+from dcsotiesplunk.config import normalize_splunk_setup_args
+
+
+class TestNormalizeSetup(unittest.TestCase):
+    def test_correct_severity_range(self):
+        # configuration ending with `_severity` has Range values
+        data = {
+            'int_severity': 1,
+            'str_severity': '6',
+            'str_lower_severity': '1-',
+            'str_upper_severity': '-4',
+            'str_upper_lower_severity': '2-5',
+        }
+
+        exp_data = {
+            'int_severity': SeverityRange(1),
+            'str_severity': SeverityRange('6'),
+            'str_lower_severity': SeverityRange('1-'),
+            'str_upper_severity': SeverityRange('-4'),
+            'str_upper_lower_severity': SeverityRange('2-5'),
+        }
+
+        normalize_splunk_setup_args(data)
+
+        for k, v in data.items():
+            self.assertIsInstance(v, SeverityRange, msg="{} not Range".format(k))
+            self.assertEqual(exp_data[k], v)
+
+    def test_incorrect_severity_range(self):
+        data = [
+            {'bad_severity': -2},  # negative integer
+            {'bad_severity': '-bad'},
+            {'bad_severity': 'bad-'},
+            {'bad_severity': 'bad-bad'},
+            {'bad_severity': '5-2'},
+        ]
+
+        for i, d in enumerate(data):
+            with self.assertRaises(TIEConfigError, msg="not raised for case #{}".format(i)) as ctx:
+                normalize_splunk_setup_args(d)
+
+            self.assertIn('bad_severity', str(ctx.exception))
+
+    def test_required_token(self):
+        with self.assertRaises(TIEConfigError) as ctx:
+            normalize_splunk_setup_args({'token': ''}, labels={'token': 'API Token'})
+
+        self.assertIn("API Token is required", str(ctx.exception))
+
+        try:
+            normalize_splunk_setup_args({'token': 'somevaluefortoken'}, labels={'token': 'API Token'})
+        except TIEConfigError as exc:
+            self.fail("exception raised; except none (was {})".format(exc))
+
+    def test_correct_confidence(self):
+        # configuration ending with `_confidence` must be Range
+        data = {
+            'int_confidence': 30,
+            'str_confidence': '60',
+            'str_lower_confidence': '10-',
+            'str_upper_confidence': '-40',
+            'str_upper_lower_confidence': '20-80',
+        }
+
+        exp_data = {
+            'int_confidence': ConfidenceRange(30),
+            'str_confidence': ConfidenceRange('60'),
+            'str_lower_confidence': ConfidenceRange('10-'),
+            'str_upper_confidence': ConfidenceRange('-40'),
+            'str_upper_lower_confidence': ConfidenceRange('20-80'),
+        }
+
+        normalize_splunk_setup_args(data)
+
+        for k, v in data.items():
+            self.assertIsInstance(v, ConfidenceRange, msg="{} not Range".format(k))
+            self.assertEqual(exp_data[k], v, msg="Range {} != Range {}".format(v, exp_data[k]))
+
+    def test_incorrect_confidence(self):
+        data = [
+            {'bad_confidence': -2},
+            {'bad_confidence': 'bad'},
+            {'bad_confidence': '10000'},
+            {'bad_confidence': '-101'},
+        ]
+
+        for i, d in enumerate(data):
+            with self.assertRaises(TIEConfigError, msg="not raised for case #{}".format(i)) as ctx:
+                normalize_splunk_setup_args(d)
+
+            self.assertIn('bad_confidence', str(ctx.exception))
+
+    def test_start_ioc_seq(self):
+        key = 'start_ioc_seq'
+        cases = [
+            {'have': 0, 'exp': 0},
+            {'have': 12345, 'exp': 12345},
+            {'have': '99999', 'exp': 99999},
+        ]
+
+        for i, case in enumerate(cases):
+            data = {key: case['have']}
+            try:
+                normalize_splunk_setup_args(data)
+            except TIEConfigError as exc:
+                self.fail("expected no exception for case #{}; got {}".format(i, exc))
+            else:
+                self.assertEqual(case['exp'], data[key])
+
+        bad_cases = ['asdfasdf', -1234, '-12345']
+
+        for i, case in enumerate(bad_cases):
+            with self.assertRaises(TIEConfigError, msg="not raised for case #{}".format(i)) as ctx:
+                normalize_splunk_setup_args({key: case})
+
+            self.assertIn(key, str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -4,8 +4,11 @@ import os
 import sys
 import unittest
 
-if __name__ == '__main__':
+try:
+    import dcsotie
+except ImportError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'lib'))
 
+if __name__ == '__main__':
     suite = unittest.TestLoader().discover('.', pattern="*_test.py")
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/tie2index/tie2index_test.py
+++ b/tests/tie2index/tie2index_test.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2020, DCSO GmbH
+
+import io
+import json
+import os
+import sys
+import unittest
+
+try:
+    import dcsotie
+except ImportError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', "lib"))
+
+from dcsotiesplunk.config import default_configuration
+from dcsotie.utils import Range
+from dcsotiesplunk.filtering import filter_iocs
+
+test_filter_data = {
+    'iocs': [
+        {'test_case': 1, 'data_type': "IPv4", 'min_severity': 1, 'max_severity': 3, 'min_confidence': 30,
+         'max_confidence': 80},
+        {'test_case': 2, 'data_type': "IPv4", 'min_severity': 0, 'max_severity': 0, 'min_confidence': 10,
+         'max_confidence': 30},
+        {'test_case': 3, 'data_type': "IPv4", 'min_severity': 0, 'max_severity': 0, 'min_confidence': 10,
+         'max_confidence': 30},
+        {'test_case': 4, 'data_type': "DomainName", 'min_severity': 2, 'max_severity': 5, 'min_confidence': 40,
+         'max_confidence': 90},
+        {'test_case': 5, 'data_type': "DomainName", 'min_severity': 0, 'max_severity': 0, 'min_confidence': 10,
+         'max_confidence': 30},
+        {'test_case': 5.1, 'data_type': "DomainName", 'min_severity': 0, 'max_severity': 0, 'min_confidence': 10,
+         'max_confidence': 90},
+        {'test_case': 6, 'data_type': "URLVerbatim", 'min_severity': 2, 'max_severity': 5, 'min_confidence': 40,
+         'max_confidence': 90},
+        {'test_case': 7, 'data_type': "URLVerbatim", 'min_severity': 0, 'max_severity': 0, 'min_confidence': 10,
+         'max_confidence': 80},
+        {'test_case': 8, 'data_type': "URLVerbatim", 'min_severity': 1, 'max_severity': 3, 'min_confidence': 10,
+         'max_confidence': 80},
+    ],
+}
+
+
+def filter_result_cases(fp: io.StringIO):
+    lines = fp.getvalue().splitlines(keepends=False)
+    return sorted([json.loads(l)['test_case'] for l in lines])
+
+
+class TestTie2Index(unittest.TestCase):
+    def test_filter_iocs(self):
+        setup = default_configuration()
+
+        fp = io.StringIO()
+        filter_iocs(test_filter_data['iocs'], setup['filter'], fp)
+
+        self.assertEqual([1, 4, 6, 8], filter_result_cases(fp))
+
+    def test_filter_iocs_with_non_malicious_url_verbatim(self):
+        setup = default_configuration()
+        setup['filter']['url_severity'] = Range(0)
+
+        fp = io.StringIO()
+        filter_iocs(test_filter_data['iocs'], setup['filter'], fp)
+
+        self.assertEqual([1, 4, 6, 7, 8], filter_result_cases(fp))
+
+    def test_filter_iocs_with_non_malicious_domain_name(self):
+        setup = default_configuration()
+        setup['filter']['dom_severity'] = Range(0)
+
+        fp = io.StringIO()
+        filter_iocs(test_filter_data['iocs'], setup['filter'], fp)
+
+        self.assertEqual([1, 4, 5.1, 6, 8], filter_result_cases(fp))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Previously, setting up the add-on it was possible to specify an integer
for severity and confidence. The IoCs would then be filtered by
allowing all what is equal or greater as the value. This works good
but it does not allow to have a finer grained result which is allowed
through the TIE API.

We add the possibility to specify ranges for Severity and Confidence.
This means that one can specify for example `1-5`, excluding IoCs with
severity 0 or 6. Similar with Confidence, 30-80 will only get you
the IoCs with confidence between 30 and 80. If you want all but 100
confidence, you can do `-99`.

Previous configured values are supported and will be used. When before
the value was `1`, this means now as a range `1-`.

The filtering has been revamped, and the big IF-statement is no more.
It is replaced with code which is checking more whether the values of
the filter made sense.

The Splunk `setup.xml` has been extended with more useful information
about how to configure. We could not figure out how to show a validation
message, so we went on creating a message to check the logs instead.

Logging was reworked so that `dcso_tie.log` now contains JSON entries.
This can be indexed through Splunk itself. Timestamps are also RFC 3336
compliant and more JS friendly.

Resolves #8