### PR TITLE
Fix seqid handling

### DIFF
--- a/bin/tie2index.py
+++ b/bin/tie2index.py
@@ -104,7 +104,7 @@ def fetch_iocs() -> NoReturn:
         logger.info("fetching IoCs using sequence number {}".format(fetcher.state['seq_number']))
 
     i = 0
-    data = fetcher.fetch(updated_since=updated_since, limit=10)
+    data = fetcher.fetch(sequence=fetcher.state['seq_number'], updated_since=updated_since, limit=10)
     try:
         while i < 50:
             i += 1

--- a/lib/dcsotie/fetchers.py
+++ b/lib/dcsotie/fetchers.py
@@ -108,7 +108,7 @@ class IoCFetcher(TIEngine):
 
         # store highest sequence
         if len(data['iocs']) > 0:
-            self.state['seq_number'] = sorted([ioc['min_seq'] for ioc in data['iocs']])[-1]
+            self.state['seq_number'] = sorted([ioc['max_seq'] for ioc in data['iocs']])[-1]
 
         try:
             if self._raw:


### PR DESCRIPTION
This PR ensures that the highest observed sequence number in the previous query that is kept in a state file is actually passed to the fetcher method in the next query. It also changes the behaviour to store the maximum of the `max_seq` value seen in the previous run, to reflect the highest seqnum of all of an IoC's observations. 

This addresses a problem where old data is read when querying the TIE, as the `seq` parameter of the REST request would never be anything but 0. Hence the query would never start at another position, and also never move forward the query window between `tie2index` invocations.